### PR TITLE
only register models on client side, fixes crash on dedicated servers

### DIFF
--- a/src/main/java/cn/davidma/mendinggems/MendingGems.java
+++ b/src/main/java/cn/davidma/mendinggems/MendingGems.java
@@ -16,6 +16,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
@@ -46,6 +48,7 @@ public class MendingGems {
 		}
 		
 		@SubscribeEvent
+                @SideOnly(Side.CLIENT)
 		public static void registerModels(ModelRegistryEvent event) {
 			ModelBakery.registerItemVariants(gem, ItemMeshGem.LESSER);
 			ModelBakery.registerItemVariants(gem, ItemMeshGem.GREATER);


### PR DESCRIPTION
This fixes an exception caused by the ItemMeshDefinition class not being present in a server only Minecraft instance, making it possible to use this mod in more multiplayer mod packs